### PR TITLE
Add css from bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "normalize.css": "~3.0.2"
+    "normalize.css": "~3.0.2",
+    "animate.css": "~3.2.0"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,13 +19,24 @@ var reload = browserSync.reload;
 var src = {
   'css': './lib/styles/*.scss',
   'js': './lib/js/**/*.js',
-  'html':'./lib/templates/*.slim'
+  'html': './lib/templates/*.slim',
 };
 var dest = {
   'css': './dist/css/',
   'js': './dist/js/',
   'html':'./dist'
 };
+
+// Process css out of bower
+gulp.task('bowerCSS', function() {
+  gulp.src(mainBowerFiles())
+  .pipe(filter('*.css', '!*.min.css'))
+  .pipe(concat('vendor.css'))
+  .pipe(rename({ suffix: '.min'}))
+  .pipe(minifycss())
+  .pipe(gulp.dest(dest.css))
+  .pipe(reload({stream:true}));
+});
 
 // Process sass
 gulp.task('sass', function() {
@@ -69,8 +80,9 @@ browserSync({
 });
 
 // Default to build, serve, and watch
-gulp.task('default', ['sass', 'slim', 'js', 'serve'], function() {
+gulp.task('default', ['bowerCSS', 'sass', 'slim', 'js', 'serve'], function() {
   gulp.watch(src.css, ['sass']);
   gulp.watch(src.html, ['slim']);
   gulp.watch(src.js, ['js']);
+  gulp.watch('bower_components', ['bowerCSS']);
 });

--- a/lib/styles/app.scss
+++ b/lib/styles/app.scss
@@ -4,3 +4,5 @@
 body {
  background: #f0f0f0;
 } 
+
+@import 'partial';

--- a/lib/templates/index.slim
+++ b/lib/templates/index.slim
@@ -1,7 +1,8 @@
 doctype 5
 html
   head
-    link rel='stylesheet' type='text/css' href='css/app.css'
+    link rel='stylesheet' type='text/css' href='css/vendor.min.css'
+    link rel='stylesheet' type='text/css' href='css/app.min.css'
 
   body
     h1 Testing


### PR DESCRIPTION
This takes any css libraries from installed via bower (animate.css, normalize.css, etc) and concatenates them into `vendor.css` then minifies into `/build/css/vendor.min.css`

Updates the index file to source that css file before any custom css.
