### PR TITLE
Run bower install on npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Make sure you have node and gulp installed:
 
 `npm install`
 
-`bower install`
-
 `gem install sass slim` *Without the `slim` gem unhandled errors abound*
 
 ####Go nuts!

--- a/lib/styles/app.scss
+++ b/lib/styles/app.scss
@@ -14,6 +14,18 @@ $zen-columns: 8;
     @include zen-grid-item(3,1);
     background: #ffc;
     overflow: hidden;
+    .cats {
+      @include zen-new-row(left);
+      @include zen-grid-item(4,1);
+    }
+    .more-cats {
+      @include zen-new-row(left);
+      @include zen-grid-item(4,1);
+    }
+    .even-more-cats {
+      @include zen-new-row(left);
+      @include zen-grid-item(4,1);
+    }
   }
   .block-a {
     @include zen-grid-item(4,1,right);
@@ -24,6 +36,11 @@ $zen-columns: 8;
     @include zen-new-row(right);
     @include zen-grid-item(4,1,right);
     background: #ffccff;
+  }
+  .block-c {
+    @include zen-new-row(right);
+    @include zen-grid-item(4,1,right);
+    background: orange;
   }
 }
 

--- a/lib/templates/index.slim
+++ b/lib/templates/index.slim
@@ -8,7 +8,19 @@ html
     .container
       .block-left
         h1 Testing
+        .cats 
+          a(href="http://thecatapi.com")
+            img(src="http://thecatapi.com/api/images/get?format=src&type=gif")
+        .more-cats
+          a(href="http://thecatapi.com")
+            img(src="http://thecatapi.com/api/images/get?format=src&type=gif")
+        .even-more-cats
+          a(href="http://thecatapi.com")
+            img(src="http://thecatapi.com/api/images/get?format=src&type=gif")
       .block-a
         p This is block a
       .block-b
         p This is block b
+      .block-c
+        p This is block c
+        

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "dependencies": {
     "gulp-slim": "0.0.10"
+  },
+  "scripts": {
+    "postinstall": "bower install"
   }
 }


### PR DESCRIPTION
I got a fresh install going and everything worked as expected.  This is sweet.  Also added some cats, and smashed some rows with the new zen-grids stuff.  Super useful.  Going to look into upgrading SI to 2.0 ...

The real change is that I added `bower install` as a postinstall to `npm install` so it will just run once npm is done.
